### PR TITLE
Added the possibility to listen to real-time configuration changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [22.5.1]
 
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nedoto-client",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "pusher-js": "^8.4.0-rc2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nedoto-client",
-  "version": "1.0.4",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,6 +8,9 @@
       "name": "nedoto-client",
       "version": "1.0.7",
       "license": "MIT",
+      "dependencies": {
+        "pusher-js": "^8.4.0-rc2"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.2",
@@ -5356,6 +5359,14 @@
         }
       ]
     },
+    "node_modules/pusher-js": {
+      "version": "8.4.0-rc2",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.4.0-rc2.tgz",
+      "integrity": "sha512-d87GjOEEl9QgO5BWmViSqW0LOzPvybvX6WA9zLUstNdB57jVJuR27zHkRnrav2a3+zAMlHbP2Og8wug+rG8T+g==",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -6084,6 +6095,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "dev": true
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT",
   "author": "Nicola Saliu<hello@nedoto.com>",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "./dist/cjs/NedotoClient.js",
   "module": "./dist/esm/NedotoClient.js",
   "types": "./dist/cjs/NedotoClient.d.ts",
@@ -47,5 +47,8 @@
     "typescript": "^5.4.5",
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4"
+  },
+  "dependencies": {
+    "pusher-js": "^8.4.0-rc2"
   }
 }

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -4,7 +4,12 @@ export class Configuration {
   private readonly createdAt: Date;
   private readonly updatedAt: Date;
 
-  constructor(type: string, value: string, createdAt: Date, updatedAt: Date) {
+  constructor(
+    type: string,
+    value: string | number | boolean | object,
+    createdAt: Date,
+    updatedAt: Date,
+  ) {
     this.type = type;
     this.value = value;
     this.createdAt = createdAt;

--- a/src/NedotoCallbackInterface.ts
+++ b/src/NedotoCallbackInterface.ts
@@ -1,8 +1,0 @@
-import { Response } from './Response';
-
-export interface NedotoCallbackInterface {
-  onVariablePushed?: (response: Response) => void;
-  onError?: (error: Response) => void;
-  onSubscriptionSucceeded?: () => void;
-  onSubscriptionError?: (error: Response) => void;
-}

--- a/src/NedotoCallbackInterface.ts
+++ b/src/NedotoCallbackInterface.ts
@@ -1,0 +1,8 @@
+import { Response } from './Response';
+
+export interface NedotoCallbackInterface {
+  onVariablePushed?: (response: Response) => void;
+  onError?: (error: Response) => void;
+  onSubscriptionSucceeded?: () => void;
+  onSubscriptionError?: (error: Response) => void;
+}

--- a/src/NedotoClient.ts
+++ b/src/NedotoClient.ts
@@ -1,10 +1,17 @@
 import { Configuration } from './Configuration';
 import { Response } from './Response';
 import { ResponseValidator } from './ResponseValidator';
+import { NedotoCallbackInterface } from './NedotoCallbackInterface';
+import Pusher from 'pusher-js';
+import { NedotoApiResponseInterface } from './NedotoApiResponseInterface';
 
 export default class NedotoClient {
   private readonly endpoint: string = 'https://app.nedoto.com/api/get/';
   private readonly apiKey: string;
+  private readonly nedotoWsAuthEndpoint: string =
+    'https://app.nedoto.com/api/ws/auth';
+  private readonly soketiEndpoint: string = 'soketi.nedoto.com';
+  private readonly soketiPort: number = 6001;
 
   constructor(apiKey: string) {
     if (apiKey.length === 0) {
@@ -50,5 +57,85 @@ export default class NedotoClient {
         new Date(json.variable.data.updated_at),
       ),
     );
+  }
+
+  public listen(
+    channelKey: string,
+    channelName: string,
+    callbacks: NedotoCallbackInterface,
+  ): () => void {
+    if (channelKey.length === 0) {
+      throw new Error('Param key is required and must be a non-empty string');
+    }
+
+    if (channelName.length === 0) {
+      throw new Error(
+        'Param channelName is required and must be a non-empty string',
+      );
+    }
+
+    const pusher = new Pusher(channelKey, {
+      wsHost: this.soketiEndpoint,
+      wsPort: this.soketiPort,
+      forceTLS: false,
+      enableStats: true,
+      enabledTransports: ['ws', 'wss'],
+      cluster: '',
+      authEndpoint: this.nedotoWsAuthEndpoint,
+      auth: {
+        headers: {
+          'X-Api-Key': this.apiKey,
+          'Access-Control-Allow-Origin': '*',
+        },
+      },
+    });
+
+    const channel = pusher.subscribe(channelName);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    channel.bind('variable-pushed', (data: any) => {
+      const apiResponse: NedotoApiResponseInterface = {
+        variable: { data: data },
+      };
+
+      const errors = new ResponseValidator(apiResponse).validate();
+
+      if (errors.length > 0) {
+        if (callbacks.onError) {
+          callbacks.onError(new Response(400, errors, null));
+        }
+      } else {
+        const response = new Response(
+          200,
+          errors,
+          new Configuration(
+            apiResponse.variable.data.type,
+            apiResponse.variable.data.value,
+            new Date(apiResponse.variable.data.created_at),
+            new Date(apiResponse.variable.data.updated_at),
+          ),
+        );
+        if (callbacks.onVariablePushed) {
+          callbacks.onVariablePushed(response);
+        }
+      }
+    });
+
+    channel.bind('pusher:subscription_succeeded', () => {
+      if (callbacks.onSubscriptionSucceeded) {
+        callbacks.onSubscriptionSucceeded();
+      }
+    });
+
+    channel.bind('pusher:subscription_error', (error: Response) => {
+      if (callbacks.onSubscriptionError) {
+        callbacks.onSubscriptionError(error);
+      }
+    });
+
+    // Return a function to unsubscribe
+    return () => {
+      pusher.unsubscribe(channelName);
+    };
   }
 }

--- a/src/RealtimeConfigurationCallbackInterface.ts
+++ b/src/RealtimeConfigurationCallbackInterface.ts
@@ -1,0 +1,15 @@
+import { Response } from './Response';
+
+export interface RealtimeConfigurationCallbackInterface {
+  // triggered when the configuration is received from the Nedoto
+  onConfigurationReceived?: (response: Response) => void;
+
+  // triggered when the subscription to the channel is successful
+  onChannelSubscriptionSucceeded?: () => void;
+
+  // triggered when the subscription to the channel fails
+  onChannelSubscriptionError?: (error: Response) => void;
+
+  // triggered when there is a generic error
+  onError?: (error: Response) => void;
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
This change introduces the possibility of listening to real-time changes (push) from Nedoto dashboard.


### 2. What does this change do, exactly?
Added a new method `listen()` to the SDK that trigger different events.


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code